### PR TITLE
Add flow control to prevent controller buffer overflow

### DIFF
--- a/interfaces/python/bable_interface/bable_interface.py
+++ b/interfaces/python/bable_interface/bable_interface.py
@@ -200,11 +200,11 @@ class BaBLEInterface(object):
             sync=sync
         )
 
-    def write_without_response(self, connection_handle, attribute_handle, value, controller_id=0, sync=False):
+    def write_without_response(self, connection_handle, attribute_handle, value, controller_id=0, timeout=2.0):
         return self._run_command(
             command_name='write_without_response',
-            params=[controller_id, connection_handle, attribute_handle, value],
-            sync=sync
+            params=[controller_id, connection_handle, attribute_handle, value, timeout],
+            sync=True
         )
 
     def set_notification(self, enabled, connection_handle, characteristic, on_notification_set=none_cb,
@@ -231,11 +231,11 @@ class BaBLEInterface(object):
             sync=sync
         )
 
-    def notify(self, connection_handle, attribute_handle, value, controller_id=0, sync=False):
+    def notify(self, connection_handle, attribute_handle, value, controller_id=0, timeout=2.0):
         return self._run_command(
             command_name='notify',
-            params=[controller_id, connection_handle, attribute_handle, value],
-            sync=sync
+            params=[controller_id, connection_handle, attribute_handle, value, timeout],
+            sync=True
         )
 
     #### Handlers registration ####

--- a/interfaces/python/bable_interface/commands/commands_py3.py
+++ b/interfaces/python/bable_interface/commands/commands_py3.py
@@ -6,7 +6,8 @@ from bable_interface.BaBLE import StartScan, StopScan, ProbeServices, ProbeChara
     WriteCentral, WriteWithoutResponseCentral, EmitNotification
 from bable_interface.BaBLE.StatusCode import StatusCode
 from bable_interface.BaBLE.Payload import Payload
-from bable_interface.utils import none_cb, string_types, switch_endianness_string, uuid_to_string, to_bytes
+from bable_interface.utils import none_cb, string_to_uuid, string_types, switch_endianness_string, uuid_to_string,\
+    to_bytes
 from bable_interface.models import BaBLEException, Characteristic, Controller, Device, Packet, PacketUuid, Service
 
 
@@ -32,12 +33,12 @@ def start_scan(self, controller_id, active_scan, on_device_found, on_scan_starte
         result = packet.get_dict([
             'controller_id',
             'type',
-            'address',
+            ('address', lambda value: value.decode()),
             ('address_type', lambda value: 'public' if value == 0 else 'random'),
             'rssi',
-            'uuid',
+            ('uuid', lambda value: string_to_uuid(value, input_byteorder='little')),
             'company_id',
-            'device_name',
+            ('device_name', lambda value: value.decode()),
             ('manufacturer_data', bytes)
         ])
 

--- a/interfaces/python/bable_interface/flatbuffers_functions.py
+++ b/interfaces/python/bable_interface/flatbuffers_functions.py
@@ -4,12 +4,12 @@ import flatbuffers
 from builtins import int
 
 # pylint:disable=unused-import
-from .BaBLE import Packet, Payload, Model, BaBLEError, CancelConnection, Characteristic, Connect, ControllerAdded, \
-    ControllerRemoved, DeviceConnected, DeviceDisconnected, DeviceFound, Disconnect, EmitNotification, Exit, \
-    GetConnectedDevices, GetControllersList, GetControllerInfo, GetControllersIds, NotificationReceived, \
-    ProbeCharacteristics, ProbeServices, ReadCentral, ReadPeripheral, Ready, Service, SetAdvertising, SetConnectable, \
-    SetDiscoverable, SetGATTTable,  SetPowered, StartScan, StopScan, WriteCentral, WritePeripheral, \
-    WriteWithoutResponseCentral, WriteWithoutResponsePeripheral
+from .BaBLE import Packet, Payload, Model, BaBLEError, CancelConnection, Characteristic, Connect, Controller, \
+    ControllerAdded, ControllerRemoved, Device, DeviceConnected, DeviceDisconnected, DeviceFound, Disconnect, \
+    EmitNotification, Exit, GetConnectedDevices, GetControllersList, GetControllerInfo, GetControllersIds, \
+    NotificationReceived, ProbeCharacteristics, ProbeServices, ReadCentral, ReadPeripheral, Ready, Service, \
+    SetAdvertising, SetConnectable, SetDiscoverable, SetGATTTable,  SetPowered, StartScan, StopScan, WriteCentral, \
+    WritePeripheral, WriteWithoutResponseCentral, WriteWithoutResponsePeripheral
 from .utils import to_bytes, MAGIC_CODE, snake_to_camel, camel_to_snake, string_types
 
 

--- a/interfaces/python/bable_interface/models/characteristic.py
+++ b/interfaces/python/bable_interface/models/characteristic.py
@@ -7,7 +7,7 @@ class Characteristic(object):
     @classmethod
     def from_flatbuffers(cls, raw_characteristic):
         return cls(
-            uuid=raw_characteristic.Uuid().decode(),
+            uuid={'uuid': raw_characteristic.Uuid().decode(), 'byteorder': 'little'},
             handle=raw_characteristic.Handle(),
             value_handle=raw_characteristic.ValueHandle(),
             config_handle=raw_characteristic.ConfigHandle(),
@@ -26,8 +26,10 @@ class Characteristic(object):
             self.uuid = uuid
         elif isinstance(uuid, string_types):
             self.uuid = string_to_uuid(uuid)
+        elif isinstance(uuid, dict):
+            self.uuid = string_to_uuid(uuid['uuid'], input_byteorder=uuid['byteorder'])
         else:
-            raise ValueError("UUID must be either a uuid.UUID object or a string")
+            raise ValueError("UUID must be either a uuid.UUID object, a dict or a string")
 
         self.handle = handle
         self.value_handle = value_handle

--- a/interfaces/python/bable_interface/models/service.py
+++ b/interfaces/python/bable_interface/models/service.py
@@ -7,7 +7,7 @@ class Service(object):
     @classmethod
     def from_flatbuffers(cls, raw_service):
         return cls(
-            uuid=raw_service.Uuid().decode(),
+            uuid={'uuid': raw_service.Uuid().decode(), 'byteorder': 'little'},
             handle=raw_service.Handle(),
             group_end_handle=raw_service.GroupEndHandle()
         )
@@ -17,8 +17,10 @@ class Service(object):
             self.uuid = uuid
         elif isinstance(uuid, string_types):
             self.uuid = string_to_uuid(uuid)
+        elif isinstance(uuid, dict):
+            self.uuid = string_to_uuid(uuid['uuid'], input_byteorder=uuid['byteorder'])
         else:
-            raise ValueError("UUID must be either a uuid.UUID object or a string")
+            raise ValueError("UUID must be either a uuid.UUID object, a dict or a string")
 
         self.handle = handle
         self.group_end_handle = group_end_handle

--- a/interfaces/python/bable_interface/utils.py
+++ b/interfaces/python/bable_interface/utils.py
@@ -5,6 +5,10 @@ from uuid import UUID
 FIRST_CAP_REGEX = re.compile('(.)([A-Z][a-z]+)')
 ALL_CAP_REGEX = re.compile('([a-z0-9])([A-Z])')
 
+MAGIC_CODE = b'\xCA\xFE'
+BASE_UUID_BT = UUID('00000000-0000-1000-8000-00805f9b34fb')
+
+
 if sys.version_info < (3, 2):
     import struct
 
@@ -56,10 +60,10 @@ else:
     string_types = str
 
 
-BASE_UUID_BT = UUID('00000000-0000-1000-8000-00805f9b34fb')
-
-
 def string_to_uuid(string, input_byteorder='big'):
+    if len(string) == 0:
+        return None
+
     string = string.replace('-', '')
     if input_byteorder == 'little':
         string = switch_endianness_string(string)
@@ -75,6 +79,9 @@ def string_to_uuid(string, input_byteorder='big'):
 
 
 def uuid_to_string(uuid, output_byteorder='little'):
+    if uuid is None:
+        return ''
+
     if uuid.hex[8:] == BASE_UUID_BT.hex[8:]:
         # 2 bytes UUID expanded with BASE_UUID_BT
         uuid2 = uuid.hex[4:8]
@@ -92,6 +99,3 @@ def uuid_to_string(uuid, output_byteorder='little'):
 
 def switch_endianness_string(be_string):
     return "".join(reversed([be_string[i:i+2] for i in range(0, len(be_string), 2)]))
-
-
-MAGIC_CODE = b'\xCA\xFE'

--- a/platforms/linux/CMakeLists.txt
+++ b/platforms/linux/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCES_FILES
         src/Application/Packets/Events/ControllerRemoved/ControllerRemoved.cpp
         src/Application/Packets/Events/AdvertisingReport/AdvertisingReport.cpp
         src/Application/Packets/Events/CommandStatus/CommandStatus.cpp
+        src/Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.cpp
         src/Application/Packets/Errors/BaBLEError/BaBLEError.cpp
         src/Application/Packets/Errors/ErrorResponse/ErrorResponse.cpp
         src/Application/Packets/Meta/GetControllersList/GetControllersList.cpp

--- a/platforms/linux/src/Application/Packets/Commands/HandleValueNotification/EmitNotification.hpp
+++ b/platforms/linux/src/Application/Packets/Commands/HandleValueNotification/EmitNotification.hpp
@@ -28,6 +28,9 @@ namespace Packet {
 
         void unserialize(FlatbuffersFormatExtractor& extractor) override;
         std::vector<uint8_t> serialize(HCIFormatBuilder& builder) const override;
+        std::vector<uint8_t> serialize(FlatbuffersFormatBuilder& builder) const override;
+
+        void prepare(const std::shared_ptr<PacketRouter>& router) override;
 
         void set_socket(AbstractSocket* socket) override;
 
@@ -37,6 +40,7 @@ namespace Packet {
         uint16_t m_attribute_handle;
         std::vector<uint8_t> m_value;
 
+        bool m_ack_to_send;
       };
 
     }

--- a/platforms/linux/src/Application/Packets/Commands/Read/Peripheral/ReadRequest.cpp
+++ b/platforms/linux/src/Application/Packets/Commands/Read/Peripheral/ReadRequest.cpp
@@ -17,9 +17,6 @@ namespace Packet {
         m_error = Format::HCI::AttributeErrorCode::None;
       }
 
-      // TODO: test with a connection from iotile coretools bled112
-
-      // TODO: add flow control WriteWithoutResponse + adapt Python part
       // TODO: split Connection into Connection/ProbeService/ProbeCharacteristics in Python part (only in BaBLE)
 
       vector<uint8_t> ReadRequest::serialize(HCIFormatBuilder& builder) const {

--- a/platforms/linux/src/Application/Packets/Commands/WriteWithoutResponse/Central/WriteWithoutResponse.hpp
+++ b/platforms/linux/src/Application/Packets/Commands/WriteWithoutResponse/Central/WriteWithoutResponse.hpp
@@ -28,6 +28,9 @@ namespace Packet {
 
         void unserialize(FlatbuffersFormatExtractor& extractor) override;
         std::vector<uint8_t> serialize(HCIFormatBuilder& builder) const override;
+        std::vector<uint8_t> serialize(FlatbuffersFormatBuilder& builder) const override;
+
+        void prepare(const std::shared_ptr<PacketRouter>& router) override;
 
         const std::string stringify() const override;
 
@@ -35,6 +38,7 @@ namespace Packet {
         uint16_t m_attribute_handle;
         std::vector<uint8_t> m_data_to_write;
 
+        bool m_ack_to_send;
       };
 
 

--- a/platforms/linux/src/Application/Packets/Events/CommandStatus/CommandStatus.cpp
+++ b/platforms/linux/src/Application/Packets/Events/CommandStatus/CommandStatus.cpp
@@ -1,5 +1,5 @@
+#include <sstream>
 #include "CommandStatus.hpp"
-#include "utils/string_formats.hpp"
 
 using namespace std;
 

--- a/platforms/linux/src/Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.cpp
+++ b/platforms/linux/src/Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.cpp
@@ -13,7 +13,6 @@ namespace Packet {
     {}
 
     void NumberOfCompletedPackets::unserialize(HCIFormatExtractor& extractor) {
-      auto length = extractor.get_value<uint8_t>();
       auto num_connection_handle = extractor.get_value<uint8_t>();
 
       for (uint8_t i = 0; i < num_connection_handle; i++) {

--- a/platforms/linux/src/Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.cpp
+++ b/platforms/linux/src/Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.cpp
@@ -1,0 +1,61 @@
+#include <sstream>
+#include "NumberOfCompletedPackets.hpp"
+#include "Transport/Socket/HCI/HCISocket.hpp"
+
+using namespace std;
+
+namespace Packet {
+
+  namespace Events {
+
+    NumberOfCompletedPackets::NumberOfCompletedPackets()
+        : ControllerToHostPacket(Packet::Id::NumberOfCompletedPackets, initial_type(), initial_packet_code(), final_packet_code(), true)
+    {}
+
+    void NumberOfCompletedPackets::unserialize(HCIFormatExtractor& extractor) {
+      auto length = extractor.get_value<uint8_t>();
+      auto num_connection_handle = extractor.get_value<uint8_t>();
+
+      for (uint8_t i = 0; i < num_connection_handle; i++) {
+        auto connection_handle = extractor.get_value<uint16_t>();
+        auto num_complete_packets = extractor.get_value<uint16_t>();
+
+        m_completed_packets.emplace_back(make_tuple(connection_handle, num_complete_packets));
+      }
+    }
+
+    void NumberOfCompletedPackets::set_socket(AbstractSocket* socket) {
+      if (m_completed_packets.empty()) {
+        return;
+      }
+
+      auto hci_socket = dynamic_cast<HCISocket*>(socket);
+      if (hci_socket == nullptr) {
+        throw Exceptions::BaBLEException(BaBLE::StatusCode::Failed, "Can't downcast socket to HCISocket packet");
+      }
+
+      for (auto& info : m_completed_packets) {
+        hci_socket->set_in_progress_packets(get<0>(info), get<1>(info));
+      }
+    }
+
+    const string NumberOfCompletedPackets::stringify() const {
+      stringstream result;
+
+      result << "<NumberOfCompletedPackets> "
+             << AbstractPacket::stringify() << ", ";
+
+      for (auto it = m_completed_packets.begin(); it != m_completed_packets.end(); ++it) {
+        result << "{ Handle: " << to_string(get<0>(*it)) << ", "
+               << "Number of completed packets: " << to_string(get<1>(*it)) << "} ";
+        if (next(it) != m_completed_packets.end()) {
+          result << ", ";
+        }
+      }
+
+      return result.str();
+    }
+
+  }
+
+}

--- a/platforms/linux/src/Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.hpp
+++ b/platforms/linux/src/Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.hpp
@@ -1,0 +1,43 @@
+#ifndef BABLE_NUMBEROFCOMPLETEDPACKETS_HPP
+#define BABLE_NUMBEROFCOMPLETEDPACKETS_HPP
+
+#include "Application/Packets/Base/ControllerToHostPacket.hpp"
+
+namespace Packet {
+
+  namespace Events {
+
+    class NumberOfCompletedPackets : public ControllerToHostPacket {
+
+    public:
+      static const Packet::Type initial_type() {
+        return Packet::Type::HCI;
+      };
+
+      static const uint16_t initial_packet_code() {
+        return Format::HCI::EventCode::NumberOfCompletedPackets;
+      };
+
+      static const uint16_t final_packet_code() {
+        return initial_packet_code();
+      };
+
+      NumberOfCompletedPackets();
+
+      void unserialize(HCIFormatExtractor& extractor) override;
+
+      void set_socket(AbstractSocket* socket) override;
+
+      const std::string stringify() const override;
+
+    private:
+      std::vector<std::tuple<uint16_t, uint16_t>> m_completed_packets;
+
+    };
+
+  }
+
+}
+
+
+#endif //BABLE_NUMBEROFCOMPLETEDPACKETS_HPP

--- a/platforms/linux/src/Application/Packets/constants.hpp
+++ b/platforms/linux/src/Application/Packets/constants.hpp
@@ -36,6 +36,7 @@ namespace Packet {
     GetControllersIdsResponse,
     GetControllersList,
     NotificationReceived,
+    NumberOfCompletedPackets,
     ProbeCharacteristics,
     ProbeServices,
     ReadRequest,

--- a/platforms/linux/src/Format/HCI/constants.hpp
+++ b/platforms/linux/src/Format/HCI/constants.hpp
@@ -154,6 +154,7 @@ namespace Format {
 
     enum EventCode {
       DisconnectComplete= 0x05,
+      NumberOfCompletedPackets= 0x13,
       CommandComplete= 0x0E,
       CommandStatus= 0x0F,
       LEMeta= 0x3E

--- a/platforms/linux/src/Transport/AbstractSocket.hpp
+++ b/platforms/linux/src/Transport/AbstractSocket.hpp
@@ -27,7 +27,7 @@ public:
     return m_controller_id;
   };
 
-  virtual bool send(const std::vector<uint8_t>& data) = 0;
+  virtual bool send(const std::vector<uint8_t>& data, uint16_t connection_handle) = 0;
   virtual void poll(OnReceivedCallback on_received, OnErrorCallback on_error) = 0;
 
   virtual void close() = 0;

--- a/platforms/linux/src/Transport/Socket/HCI/HCISocket.cpp
+++ b/platforms/linux/src/Transport/Socket/HCI/HCISocket.cpp
@@ -143,6 +143,8 @@ bool HCISocket::send(const vector<uint8_t>& data, uint16_t connection_handle) {
       if (num_in_progress_packets >= m_buffer_size) {
         throw Exceptions::BaBLEException(BaBLE::StatusCode::Rejected, "Controller buffer full");
       }
+
+//      LOG.debug(to_string(m_buffer_size - num_in_progress_packets) + " remaining slots in controller buffer.", "HCISocket");
     }
 
 //    LOG.debug("Sending data...", "HCISocket");
@@ -241,6 +243,8 @@ void HCISocket::set_in_progress_packets(uint16_t connection_handle, uint16_t num
   } else {
     it->second -= num_packets_processed;
   }
+
+//  LOG.debug(to_string(num_packets_processed) + " packets processed.", "HCISocket");
 }
 
 void HCISocket::close() {

--- a/platforms/linux/src/Transport/Socket/HCI/HCISocket.cpp
+++ b/platforms/linux/src/Transport/Socket/HCI/HCISocket.cpp
@@ -56,7 +56,7 @@ HCISocket::HCISocket(uv_loop_t* loop, shared_ptr<HCIFormat> format, uint16_t con
   m_hci_socket->bind(m_controller_id, HCI_CHANNEL_RAW);
 
   LOG.debug("Getting HCI controller address...", "HCISocket");
-  find_controller_address();
+  get_controller_info();
 
   LOG.debug("Setting up poller on HCI socket...", "HCISocket");
   m_poller = make_unique<uv_poll_t>();
@@ -66,14 +66,14 @@ HCISocket::HCISocket(uv_loop_t* loop, shared_ptr<HCIFormat> format, uint16_t con
   LOG.debug("HCI socket created on " + Utils::format_bd_address(m_controller_address), "HCISocket");
 }
 
-bool HCISocket::find_controller_address() {
+bool HCISocket::get_controller_info() {
   struct Format::HCI::hci_dev_info di{};
   di.dev_id = m_controller_id;
 
   // To get the controller address
   m_hci_socket->ioctl(HCIGETDEVINFO, (void *)&di);
-
-  copy(begin(di.bdaddr.b), end(di.bdaddr.b), m_controller_address.begin());
+  m_buffer_size = di.acl_pkts;
+  copy(begin(di.bdaddr.b, end(di.bdaddr.b), m_controller_address.begin()));
   return true;
 }
 

--- a/platforms/linux/src/Transport/Socket/HCI/HCISocket.hpp
+++ b/platforms/linux/src/Transport/Socket/HCI/HCISocket.hpp
@@ -26,6 +26,8 @@ public:
   std::vector<Format::HCI::Service> get_services() const;
   std::vector<Format::HCI::Characteristic> get_characteristics() const;
 
+  void set_in_progress_packets(uint16_t connection_handle, uint16_t num_packets_processed);
+
   std::string get_controller_address();
 
   void close() override;
@@ -45,6 +47,7 @@ private:
 
   std::array<uint8_t, 6> m_controller_address{};
   uint16_t m_buffer_size;
+  std::unordered_map<uint16_t, uint16_t> m_in_progress_packets;
   std::unordered_map<uint16_t, Socket> m_l2cap_sockets;
 
   std::unique_ptr<uv_poll_t> m_poller;

--- a/platforms/linux/src/Transport/Socket/HCI/HCISocket.hpp
+++ b/platforms/linux/src/Transport/Socket/HCI/HCISocket.hpp
@@ -39,11 +39,12 @@ protected:
 
 private:
   bool set_filters();
-  bool find_controller_address();
+  bool get_controller_info();
 
   std::vector<uint8_t> receive();
 
   std::array<uint8_t, 6> m_controller_address{};
+  uint16_t m_buffer_size;
   std::unordered_map<uint16_t, Socket> m_l2cap_sockets;
 
   std::unique_ptr<uv_poll_t> m_poller;

--- a/platforms/linux/src/Transport/Socket/HCI/HCISocket.hpp
+++ b/platforms/linux/src/Transport/Socket/HCI/HCISocket.hpp
@@ -16,7 +16,7 @@ public:
   explicit HCISocket(uv_loop_t* loop, std::shared_ptr<HCIFormat> format, uint16_t controller_id);
   explicit HCISocket(uv_loop_t* loop, std::shared_ptr<HCIFormat> format, uint16_t controller_id, std::shared_ptr<Socket> hci_socket);
 
-  bool send(const std::vector<uint8_t>& data) override;
+  bool send(const std::vector<uint8_t>& data, uint16_t connection_handle) override;
   void poll(OnReceivedCallback on_received, OnErrorCallback on_error) override;
 
   void connect_l2cap_socket(uint16_t connection_handle, const std::array<uint8_t, 6>& device_address, uint8_t device_address_type);
@@ -52,7 +52,7 @@ private:
 
   std::unique_ptr<uv_poll_t> m_poller;
 
-  std::queue<std::vector<uint8_t>> m_send_queue;
+  std::queue<std::tuple<std::vector<uint8_t>, uint16_t>> m_send_queue;
   bool m_writable;
 
   std::vector<Format::HCI::Service> m_services;

--- a/platforms/linux/src/Transport/Socket/MGMT/MGMTSocket.cpp
+++ b/platforms/linux/src/Transport/Socket/MGMT/MGMTSocket.cpp
@@ -28,7 +28,7 @@ MGMTSocket::MGMTSocket(uv_loop_t* loop, shared_ptr<MGMTFormat> format, shared_pt
   LOG.debug("MGMT socket created", "MGMTSocket");
 }
 
-bool MGMTSocket::send(const vector<uint8_t>& data) {
+bool MGMTSocket::send(const vector<uint8_t>& data, uint16_t connection_handle) {
   if (!m_writable) {
     LOG.debug("Already sending a message. Queuing...", "MGMTSocket");
     m_send_queue.push(data);
@@ -104,7 +104,7 @@ void MGMTSocket::set_writable(bool is_writable) {
 
   if (m_writable) {
     if (!m_send_queue.empty()) {
-      send(reinterpret_cast<const vector<uint8_t>&>(m_send_queue.front()));
+      send(reinterpret_cast<const vector<uint8_t>&>(m_send_queue.front()), 0);
       m_send_queue.pop();
     }
   }

--- a/platforms/linux/src/Transport/Socket/MGMT/MGMTSocket.hpp
+++ b/platforms/linux/src/Transport/Socket/MGMT/MGMTSocket.hpp
@@ -13,7 +13,7 @@ public:
   explicit MGMTSocket(uv_loop_t* loop, std::shared_ptr<MGMTFormat> format);
   explicit MGMTSocket(uv_loop_t* loop, std::shared_ptr<MGMTFormat> format, std::shared_ptr<Socket> socket);
 
-  bool send(const std::vector<uint8_t>& data) override;
+  bool send(const std::vector<uint8_t>& data, uint16_t connection_handle) override;
   void poll(OnReceivedCallback on_received, OnErrorCallback on_error) override;
 
   void close() override;

--- a/platforms/linux/src/Transport/Socket/StdIO/StdIOSocket.cpp
+++ b/platforms/linux/src/Transport/Socket/StdIO/StdIOSocket.cpp
@@ -18,7 +18,7 @@ StdIOSocket::StdIOSocket(uv_loop_t* loop, shared_ptr<AbstractFormat> format)
   m_on_close_callback = []() {};
 }
 
-bool StdIOSocket::send(const vector<uint8_t>& data) {
+bool StdIOSocket::send(const vector<uint8_t>& data, uint16_t connection_handle) {
   vector<uint8_t> header = generate_header(data);
 
   fwrite(header.data(), sizeof(uint8_t), header.size(), stdout);

--- a/platforms/linux/src/Transport/Socket/StdIO/StdIOSocket.hpp
+++ b/platforms/linux/src/Transport/Socket/StdIO/StdIOSocket.hpp
@@ -13,11 +13,11 @@ public:
 
   StdIOSocket(uv_loop_t* loop, std::shared_ptr<AbstractFormat> format);
 
-  bool send(const std::vector<uint8_t>& data) override;
+  bool send(const std::vector<uint8_t>& data, uint16_t connection_handle) override;
   void poll(OnReceivedCallback on_received, OnErrorCallback on_error) override;
 
   void on_close(OnCloseCallback on_close);
-  void close();
+  void close() override;
 
 protected:
   static void on_poll(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);

--- a/platforms/linux/src/Transport/SocketContainer/SocketContainer.cpp
+++ b/platforms/linux/src/Transport/SocketContainer/SocketContainer.cpp
@@ -28,7 +28,7 @@ bool SocketContainer::send(const shared_ptr<Packet::AbstractPacket>& packet) {
   Packet::Type packet_type = packet->get_type();
 
   if (packet_type == Packet::Type::NONE) {
-    LOG.debug("Packet ignored: " + packet->stringify());
+    // LOG.debug("Packet ignored: " + packet->stringify());
     return true;
   }
 
@@ -52,7 +52,7 @@ bool SocketContainer::send(const shared_ptr<Packet::AbstractPacket>& packet) {
   vector<uint8_t> data = packet->to_bytes();
 
   try {
-    bool result = socket->send(data);
+    bool result = socket->send(data, packet->get_connection_handle());
     return result;
 
   } catch (Exceptions::BaBLEException& err) {

--- a/platforms/linux/src/main.cpp
+++ b/platforms/linux/src/main.cpp
@@ -143,7 +143,9 @@ int main(int argc, char* argv[]) {
         return;
       }
 
-      if (packet->get_id() == Packet::Id::SetGATTTable) {
+      Packet::Id packet_id = packet->get_id();
+
+      if (packet_id == Packet::Id::SetGATTTable) {
         shared_ptr<AbstractSocket> base_socket = socket_container.get_socket(Packet::Type::HCI, packet->get_controller_id());
         packet->set_socket(dynamic_cast<HCISocket*>(base_socket.get()));
       } else {
@@ -155,6 +157,11 @@ int main(int argc, char* argv[]) {
       packet->prepare(packet_router);
 
       socket_container.send(packet);
+
+      if (packet_id == Packet::Id::WriteWithoutResponse || packet_id == Packet::Id::EmitNotification) {
+        packet->prepare(packet_router);
+        socket_container.send(packet);
+      }
     },
     on_error
   );

--- a/platforms/linux/src/main.cpp
+++ b/platforms/linux/src/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, char* argv[]) {
   LOG.debug("Creating socket pollers...");
 
   auto on_error = [&stdio_socket, &socket_container](const Exceptions::BaBLEException& err) {
-    LOG.error(err.get_message(), "Error");
+    LOG.debug(err.get_message(), "Error");
     shared_ptr<Packet::Errors::BaBLEError> error_packet = make_shared<Packet::Errors::BaBLEError>(err);
     socket_container.send(error_packet);
   };

--- a/platforms/linux/src/registration.hpp
+++ b/platforms/linux/src/registration.hpp
@@ -1,7 +1,6 @@
 #ifndef BABLE_REGISTRATION_CPP
 #define BABLE_REGISTRATION_CPP
 
-#include <Application/Packets/Commands/HandleValueNotification/EmitNotification.hpp>
 #include "Application/PacketBuilder/PacketBuilder.hpp"
 #include "Application/Packets/Commands/Disconnect/Disconnect.hpp"
 #include "Application/Packets/Commands/SetPowered/SetPoweredRequest.hpp"
@@ -34,6 +33,7 @@
 #include "Application/Packets/Commands/GetConnectedDevices/GetConnectedDevices.hpp"
 #include "Application/Packets/Commands/CreateConnection/CreateConnection.hpp"
 #include "Application/Packets/Commands/CancelConnection/CancelConnectionRequest.hpp"
+#include "Application/Packets/Commands/HandleValueNotification/EmitNotification.hpp"
 #include "Application/Packets/Events/DeviceConnected/DeviceConnected.hpp"
 #include "Application/Packets/Events/DeviceDisconnected/DeviceDisconnected.hpp"
 #include "Application/Packets/Events/ControllerAdded/ControllerAdded.hpp"
@@ -41,6 +41,7 @@
 #include "Application/Packets/Events/AdvertisingReport/AdvertisingReport.hpp"
 #include "Application/Packets/Events/CommandComplete/CommandComplete.hpp"
 #include "Application/Packets/Events/CommandStatus/CommandStatus.hpp"
+#include "Application/Packets/Events/NumberOfCompletedPackets/NumberOfCompletedPackets.hpp"
 #include "Application/Packets/Control/SetGATTTable/SetGATTTable.hpp"
 #include "Application/Packets/Control/Exit/Exit.hpp"
 #include "Application/Packets/Control/Ready/Ready.hpp"
@@ -95,6 +96,7 @@ void register_hci_packets(PacketBuilder& hci_packet_builder) {
     .register_event<Packet::Events::AdvertisingReport>()
     .register_event<Packet::Events::CommandComplete>()
     .register_event<Packet::Events::CommandStatus>()
+    .register_event<Packet::Events::NumberOfCompletedPackets>()
     .set_ignored_packets({
       Format::HCI::SubEventCode::LEReadRemoteUsedFeaturesComplete,
       Format::HCI::SubEventCode::LEConnectionUpdateComplete,

--- a/platforms/linux/tests/mocks/mock_socket.hpp
+++ b/platforms/linux/tests/mocks/mock_socket.hpp
@@ -47,6 +47,7 @@ public:
       bdaddr_t bdaddr{};
       std::copy(m_address.begin(), m_address.end(), std::begin(bdaddr.b));
       dev->bdaddr = bdaddr;
+      dev->acl_pkts = 1;
     };
   };
 

--- a/platforms/linux/tests/mocks/mock_stdio_socket.hpp
+++ b/platforms/linux/tests/mocks/mock_stdio_socket.hpp
@@ -11,7 +11,7 @@ public:
     m_stream->data = this;
   };
 
-  bool send(const std::vector<uint8_t>& data) override {
+  bool send(const std::vector<uint8_t>& data, uint16_t connection_handle) override {
     m_buffers.push_back(data);
   };
 


### PR DESCRIPTION
Fixes #17 

Now we probe the controller for its buffer size on startup and control that we never exceed this limit when we send an HCI packet. If we can't send a packet, a "Rejected" error is sent. The user will just have to wait a bit before retrying.
To know how many packets have been processed, we use the `Number of completed packets` HCI event. 

Moreover, packets without response like `WriteWithoutResponse` and `EmitNotification` now have an acknowledgement from the C++ part to confirm that the packet has been sent to the HCI socket.